### PR TITLE
Use the correct consumer group lag metric

### DIFF
--- a/files/configs/kafka-config.yaml
+++ b/files/configs/kafka-config.yaml
@@ -68,6 +68,11 @@ rules:
 - pattern : kafka.server<type=(.+), name=(.+)><>(Count|Value)
   name: kafka_server_$1_$2
 
+- pattern: kafka.consumer<type=(ConsumerFetcherManager), name=(MaxLag), clientId=(.+)><>(Count|Value)
+  name: kafka_consumer_$1_$2
+  labels:
+    clientId: "$3"
+
 - pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
   name: kafka_$1_$2_$3_total
 - pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count
@@ -88,8 +93,3 @@ rules:
   name: kafka_$1_$2_$3_$6
   labels:
     "$4": "$5"
-
-- pattern: kafka.consumer<type=(.+), client-id=(.+)><>(records-lag-max)
-  name: kafka_$1_$3
-  labels:
-    clientId: "$2"


### PR DESCRIPTION
`kafka.consumer:type=ConsumerFetcherManager,name=MaxLag` is the correct one that _brokers_ have access to. The `records-lag-max` one is for _consumer clients_.